### PR TITLE
[History] Take out unnecessary check to fix setting vals in inspector

### DIFF
--- a/RuntimeUnityEditor/Windows/ChangeHistory/Change.cs
+++ b/RuntimeUnityEditor/Windows/ChangeHistory/Change.cs
@@ -52,9 +52,6 @@ namespace RuntimeUnityEditor.Core.ChangeHistory
             if (member == null)
                 throw new ArgumentNullException(nameof(member));
 
-            if (member.DeclaringType != typeof(TObj))
-                throw new ArgumentException("Member must be declared in the type of the target object", nameof(member));
-
             if (member is PropertyInfo pi)
             {
                 void PropSet(TObj obj, TVal val) => pi.SetValue(obj, val, null);


### PR DESCRIPTION
The check has too many false positives and is redundant since it will throw anyways later on if the type is actually wrong.