### PR TITLE
Aggregate button added

### DIFF
--- a/RuntimeUnityEditor/Utils/MovingAverage.cs
+++ b/RuntimeUnityEditor/Utils/MovingAverage.cs
@@ -21,6 +21,9 @@ namespace RuntimeUnityEditor.Core.Utils
 
         public long GetAverage()
         {
+            if (_samples.Count == 0)
+                return 0;
+
             return _sampleAccumulator / _samples.Count;
         }
 

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -332,10 +332,9 @@ namespace RuntimeUnityEditor.Core.Profiler
                     if ( _aggregation )
                     {
                         infos = infos
-                            .GroupBy(x => x.FullName)
+                            .GroupBy(x => new KeyValuePair<string,bool>(x.FullName, x.SinceLastRun < 2))
                             .Select(group =>
                                 group
-                                    .Where(pi => pi.SinceLastRun < 2)
                                     .Aggregate(new ProfilerInfo(group.First(), group.First().FullName),
                                 (a, b) => ProfilerInfo.Merge(a, b))
                                 );
@@ -444,6 +443,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                 _executionOrder = parent._executionOrder;
                 HighestExecutionOrder = parent.HighestExecutionOrder;
                 Instances = 0;
+                SinceLastRun = parent.SinceLastRun;
             }
 
             static public ProfilerInfo Merge( ProfilerInfo x, ProfilerInfo y )

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -332,7 +332,9 @@ namespace RuntimeUnityEditor.Core.Profiler
                         infos = infos
                             .GroupBy(x => x.FullName)
                             .Select(group =>
-                                group.Aggregate(new ProfilerInfo(group.First(), $"{group.First().FullName}"),
+                                group
+                                    .Where(pi => pi.SinceLastRun < 2)
+                                    .Aggregate(new ProfilerInfo(group.First(), $"{group.First().FullName}"),
                                 (a, b) => ProfilerInfo.Merge(a, b))
                                 );
                     }

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -295,6 +295,8 @@ namespace RuntimeUnityEditor.Core.Profiler
 
         private IEnumerator FrameEndCo()
         {
+            bool prevAggregation = false; 
+
             while (true)
             {
                 yield return _waitForEndOfFrame;
@@ -303,7 +305,7 @@ namespace RuntimeUnityEditor.Core.Profiler
 
                 _currentExecutionCount = 0;
 
-                if (_ordering == 1 || _ordering == 2)
+                if (_ordering == 1 || _ordering == 2 || prevAggregation != _aggregation )
                     _needResort = true;
 
                 if (!_pause)
@@ -351,6 +353,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                 }
 
                 _needResort = false;
+                prevAggregation = _aggregation;
             }
         }
 

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -176,7 +176,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                                 if (!_aggregation)
                                     GUILayout.Toggle(pd.OriginalRan, GUIContent.none, _cRanW2); // enabled
                                 else
-                                    GUILayout.Space(RanW);
+                                    GUILayout.Space(RanW + 4);
 
                                 var ticks = pd.TicksSpent.GetAverage();
                                 var ms = ConvertTicksToMs(ticks);

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -332,7 +332,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                         infos = infos
                             .GroupBy(x => x.FullName)
                             .Select(group =>
-                                group.Aggregate(new ProfilerInfo(group.First(), $"[{group.Count(),3}] {group.First().FullName}"),
+                                group.Aggregate(new ProfilerInfo(group.First(), $"{group.First().FullName}"),
                                 (a, b) => ProfilerInfo.Add(a, b))
                                 );
                     }
@@ -445,8 +445,8 @@ namespace RuntimeUnityEditor.Core.Profiler
                 ProfilerInfo sum = new ProfilerInfo(x);
                 sum.TicksSpent.Sample(x.TicksSpent.GetAverage() + y.TicksSpent.GetAverage());
                 sum.GcBytes.Sample(x.GcBytes.GetAverage() + y.GcBytes.GetAverage());
-                return sum;
                 sum.Instances = x.Instances + y.Instances;
+                return sum;
             }
         }
 

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -397,12 +397,12 @@ namespace RuntimeUnityEditor.Core.Profiler
 
             public int Instances;
 
+            internal uint SinceLastRun;
             internal int HighestExecutionOrder;
             public bool OriginalRan;
 
             public bool PostfixRan;
 
-            internal byte SinceLastRun;
 
             public ProfilerInfo(MethodBase method, MonoBehaviour owner, EventType guiEvent = (EventType)(-1))
             {

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -394,7 +394,7 @@ namespace RuntimeUnityEditor.Core.Profiler
 
             public long GcBytesAtStart;
 
-            public int Instances;
+            public uint Instances;
 
             internal uint SinceLastRun;
             internal int HighestExecutionOrder;

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -295,8 +295,6 @@ namespace RuntimeUnityEditor.Core.Profiler
 
         private IEnumerator FrameEndCo()
         {
-            bool prevAggregation = false; 
-
             while (true)
             {
                 yield return _waitForEndOfFrame;
@@ -305,7 +303,7 @@ namespace RuntimeUnityEditor.Core.Profiler
 
                 _currentExecutionCount = 0;
 
-                if (_ordering == 1 || _ordering == 2 || prevAggregation != _aggregation )
+                if (_ordering == 1 || _ordering == 2 )
                     _needResort = true;
 
                 if (!_pause)
@@ -323,7 +321,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                     }
                 }
 
-                if (_needResort)
+                if (_needResort || _aggregation)
                 {
                     _dataDisplay.Clear();
 
@@ -335,7 +333,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                             .GroupBy(x => x.FullName)
                             .Select(group =>
                                 group.Aggregate(new ProfilerInfo(group.First(), $"{group.First().FullName}"),
-                                (a, b) => ProfilerInfo.Add(a, b))
+                                (a, b) => ProfilerInfo.Merge(a, b))
                                 );
                     }
 
@@ -353,7 +351,6 @@ namespace RuntimeUnityEditor.Core.Profiler
                 }
 
                 _needResort = false;
-                prevAggregation = _aggregation;
             }
         }
 
@@ -443,7 +440,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                 Instances = 0;
             }
 
-            static public ProfilerInfo Add( ProfilerInfo x, ProfilerInfo y )
+            static public ProfilerInfo Merge( ProfilerInfo x, ProfilerInfo y )
             {
                 ProfilerInfo sum = new ProfilerInfo(x);
                 sum.TicksSpent.Sample(x.TicksSpent.GetAverage() + y.TicksSpent.GetAverage());

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -18,11 +18,12 @@ namespace RuntimeUnityEditor.Core.Profiler
     public sealed class ProfilerWindow : Window<ProfilerWindow>
     {
         private const string OnGuiMethodName = "OnGUI";
+        private const int RanW = 25;
         private static readonly string[] _orderingStrings = { "#", "Time", "Memory", "Name" };
         private static readonly GUILayoutOption[] _cGcW = { GUILayout.MinWidth(50), GUILayout.MaxWidth(50) };
         private static readonly GUILayoutOption[] _cOrderW = { GUILayout.MinWidth(30), GUILayout.MaxWidth(30) };
         private static readonly GUILayoutOption[] _cRanHeaderW = { GUILayout.MinWidth(43), GUILayout.MaxWidth(43) };
-        private static readonly GUILayoutOption[] _cRanW2 = { GUILayout.MinWidth(25), GUILayout.MaxWidth(25) };
+        private static readonly GUILayoutOption[] _cRanW2 = { GUILayout.MinWidth(RanW), GUILayout.MaxWidth(RanW) };
         private static readonly GUILayoutOption[] _cTicksW = { GUILayout.MinWidth(50), GUILayout.MaxWidth(50) };
         private static readonly GUILayoutOption[] _cInsW = { GUILayout.MinWidth(50), GUILayout.MaxWidth(50) };
         private static readonly GUILayoutOption[] _expandW = { GUILayout.ExpandWidth(true) };
@@ -172,7 +173,10 @@ namespace RuntimeUnityEditor.Core.Profiler
                                 if (!ran && !pd.Owner) _needResort = true;
 
                                 GUILayout.Toggle(ran, GUIContent.none); // enabled
-                                GUILayout.Toggle(pd.OriginalRan, GUIContent.none, _cRanW2); // enabled
+                                if (!_aggregation)
+                                    GUILayout.Toggle(pd.OriginalRan, GUIContent.none, _cRanW2); // enabled
+                                else
+                                    GUILayout.Space(RanW);
 
                                 var ticks = pd.TicksSpent.GetAverage();
                                 var ms = ConvertTicksToMs(ticks);

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -436,7 +436,8 @@ namespace RuntimeUnityEditor.Core.Profiler
                 DisplayName = FullName;
                 Timer = new Stopwatch();
                 GuiEvent = parent.GuiEvent;
-                ExecutionOrder = parent._executionOrder;
+                _executionOrder = parent._executionOrder;
+                HighestExecutionOrder = parent.HighestExecutionOrder;
                 Instances = 0;
             }
 
@@ -446,6 +447,8 @@ namespace RuntimeUnityEditor.Core.Profiler
                 sum.TicksSpent.Sample(x.TicksSpent.GetAverage() + y.TicksSpent.GetAverage());
                 sum.GcBytes.Sample(x.GcBytes.GetAverage() + y.GcBytes.GetAverage());
                 sum.Instances = x.Instances + y.Instances;
+                sum._executionOrder = Math.Max(x._executionOrder, y._executionOrder);
+                sum.HighestExecutionOrder = Math.Max(x.HighestExecutionOrder, y.HighestExecutionOrder);
                 return sum;
             }
         }

--- a/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
+++ b/RuntimeUnityEditor/Windows/Profiler/ProfilerWindow.cs
@@ -295,6 +295,8 @@ namespace RuntimeUnityEditor.Core.Profiler
 
         private IEnumerator FrameEndCo()
         {
+            bool prevAggregation = false;
+
             while (true)
             {
                 yield return _waitForEndOfFrame;
@@ -321,7 +323,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                     }
                 }
 
-                if (_needResort || _aggregation)
+                if (_needResort || _aggregation || prevAggregation != _aggregation)
                 {
                     _dataDisplay.Clear();
 
@@ -334,7 +336,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                             .Select(group =>
                                 group
                                     .Where(pi => pi.SinceLastRun < 2)
-                                    .Aggregate(new ProfilerInfo(group.First(), $"{group.First().FullName}"),
+                                    .Aggregate(new ProfilerInfo(group.First(), group.First().FullName),
                                 (a, b) => ProfilerInfo.Merge(a, b))
                                 );
                     }
@@ -353,6 +355,7 @@ namespace RuntimeUnityEditor.Core.Profiler
                 }
 
                 _needResort = false;
+                prevAggregation = _aggregation;
             }
         }
 


### PR DESCRIPTION
Aggregate button added. It aggregates ticks and gcbytes of the same function.
Please merge if you like.

![aggregation](https://github.com/ManlyMarco/RuntimeUnityEditor/assets/4230203/c4621efc-d739-4c7d-ab9e-9face9d05479)

It was clear that DynamicBone was the slowest, but we wanted to be sure. I also wanted to make sure that there were not a large number of instances at the bottom of the list that would cause slowness.