### PR TITLE
fix wireframe

### DIFF
--- a/RuntimeUnityEditor/Features/WireframeFeature.cs
+++ b/RuntimeUnityEditor/Features/WireframeFeature.cs
@@ -16,7 +16,7 @@ namespace RuntimeUnityEditor.Core
         private MonoBehaviour _monoBehaviour;
 
         //Effects incompatible with wireframes.
-        private static string[] _DisableEffectNames = { "GlobalFog", "BloomAndFlares", "CustomRender", "AmplifyColorEffect" };
+        private static string[] _DisableEffectNames = { "GlobalFog", "BloomAndFlares", "CustomRender", "AmplifyColorEffect", "PostProcessLayer" };
 
         private List<Behaviour> _disabledEffects = new List<Behaviour>();
 


### PR DESCRIPTION
I attempted to fix #37.
When checked with KKS/KK/HS2, the wireframe did not render and blue screened.

Before:
![failedh2](https://github.com/ManlyMarco/RuntimeUnityEditor/assets/4230203/d5ad5aee-2a05-48b9-93db-842d1d80c358)

A game-specific fix for Illusion was needed.
CameraClearFlags was not needed and certain post-effects needed to be disabled.
However, I can imagine that some games may require CameraClearFlags.

After:
![ok](https://github.com/ManlyMarco/RuntimeUnityEditor/assets/4230203/8a1f5c5b-879c-4e69-b836-6afb8dd8ae8b)

What should I do with this code?
Should I check the process name or something to separate the processes?
If it is not good for applications other than Illusion, then we can discard this code.