### PR TITLE
Fix search problems in ObjectBrowser

### DIFF
--- a/RuntimeUnityEditor/Utils/Extensions.cs
+++ b/RuntimeUnityEditor/Utils/Extensions.cs
@@ -18,6 +18,8 @@ namespace RuntimeUnityEditor.Core.Utils
     {
         public static bool Contains(this string s, string searchText, StringComparison sc)
         {
+            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(searchText))
+                return false;
             return s.IndexOf(searchText, sc) >= 0;
         }
 

--- a/RuntimeUnityEditor/Windows/ObjectTree/RootGameObjectSearcher.cs
+++ b/RuntimeUnityEditor/Windows/ObjectTree/RootGameObjectSearcher.cs
@@ -436,13 +436,11 @@ namespace RuntimeUnityEditor.Core.ObjectTree
 
                 if (timer.ElapsedMilliseconds > 20)
                 {
-                    timer.Reset();
                     _indexingTimer.Stop();
 
                     yield return null;
 
                     _indexingTimer.Start();
-                    timer.Start();
 
                     _searchResults = DoSearch();
 
@@ -451,6 +449,9 @@ namespace RuntimeUnityEditor.Core.ObjectTree
                         RuntimeUnityEditorCore.Logger.Log(LogLevel.Debug, "Restarting indexing...");
                         goto Restart;
                     }
+
+                    timer.Reset();
+                    timer.Start();
                 }
             }
 


### PR DESCRIPTION
Fixed two search issues in ObjectBrowser.
If it's okay, please merge it.

1. The string became null and an exception occurred.

```
ArgumentNullException: Value cannot be null.
Parameter name: value
  at System.String.IndexOf (System.String value, System.Int32 startIndex, System.Int32 count, System.StringComparison comparisonType) [0x00003] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.String.IndexOf (System.String value, System.StringComparison comparisonType) [0x00009] in <fb001e01371b4adca20013e0ac763896>:0 
  at RuntimeUnityEditor.Core.Utils.Extensions.Contains (System.String s, System.String searchText, System.StringComparison sc) [0x00000] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at RuntimeUnityEditor.Core.ObjectTree.RootGameObjectSearcher+SearchStrings.Match (System.String searchString, System.Boolean searchNames, System.Boolean searchComponents, System.Boolean searchProperties) [0x00003] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at RuntimeUnityEditor.Core.ObjectTree.RootGameObjectSearcher.<DoSearch>b__26_2 (UnityEngine.GameObject go) [0x00012] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at RuntimeUnityEditor.Core.Utils.ThreadingExtensions+<>c__DisplayClass1_1`2[TIn,TOut].<RunParallel>b__0 (System.Object _) [0x00044] in <cb390b30800d4d939dd0beddff9156e8>:0 
Rethrow as TargetInvocationException: An exception was thrown inside one of the threads
  at RuntimeUnityEditor.Core.Utils.ThreadingExtensions+<RunParallel>d__1`2[TIn,TOut].MoveNext () [0x0024e] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at System.Linq.Enumerable+WhereEnumerableIterator`1[TSource].ToArray () [0x00033] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Buffer`1[TElement]..ctor (System.Collections.Generic.IEnumerable`1[T] source) [0x0000a] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.OrderedEnumerable`1+<GetEnumerator>d__3[TElement].MoveNext () [0x0001e] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable+SelectIPartitionIterator`2[TSource,TResult].ToList () [0x00052] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable.ToList[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0001f] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at RuntimeUnityEditor.Core.ObjectTree.RootGameObjectSearcher.DoSearch () [0x00115] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at RuntimeUnityEditor.Core.ObjectTree.RootGameObjectSearcher+<IndexObjectsCo>d__34.MoveNext () [0x0021f] in <cb390b30800d4d939dd0beddff9156e8>:0 
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00026] in <548b4fa0e7e04f27a1b7580930bfb7dc>:0 
 
(Filename: <fb001e01371b4adca20013e0ac763896> Line: 0)
```

2. Index generation may be slow.

If there are too many objects, the PC's specifications are low, or both of these apply, the phenomenon of the index generation never ending will occur. In my environment, the manufacturer of Sunshine, the search function almost stopped working.
If more than 20ms is consumed within DoSearch(), only one index will be generated per frame. In that case, the search will not finish.

